### PR TITLE
Sopel 8 moved built-in plugins from `.modules` to `.builtins`

### DIFF
--- a/sopel_meetbot/plugin.py
+++ b/sopel_meetbot/plugin.py
@@ -17,7 +17,7 @@ import time
 
 from sopel import formatting, plugin, tools
 from sopel.config import types
-from sopel.modules.url import find_title
+from sopel.builtins.url import find_title
 
 
 UNTITLED_MEETING = "Untitled meeting"


### PR DESCRIPTION
Title. Existing plugin release (1.0.0) will not load on Sopel 8.x because of the `ImportError`.